### PR TITLE
Fix compilation on gcc 8+

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -37,6 +37,6 @@ ifeq ($(UNAME_SYS), darwin)
 endif
 
 CXXFLAGS += -DNDEBUG -I pugixml \
-			-g -Wextra -Werror -Wno-missing-field-initializers -fno-exceptions -fno-rtti -std=c++11
+			-g -Wextra -Werror -Wno-ignored-qualifiers -Wno-missing-field-initializers -fno-exceptions -fno-rtti -std=c++11
 
 LDFLAGS +=  -lstdc++


### PR DESCRIPTION
This change addresses the error on compile:
```
error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
```

Tested on gcc 6.4.0, 8.3.0, 9.2.0

---

Full error message on compile:

```
make[1]: Entering directory '/app/c_src'
 CPP    utf8_cleanup.cc
 CPP    xmlstreamparser.cc
 CPP    erlxml_nif.cc
 CPP    pugixml.cpp
 CPP    bytebuffer.cc
 CPP    erlxml.cc
 CPP    nif_utils.cc
 CPP    allocators.cc
 CPP    element_encoder.cc
In file included from /usr/lib/erlang/erts-10.2.4/include/erl_nif.h:306,
                 from /app/c_src/erlxml.h:4,
                 from /app/c_src/erlxml.cc:1:
/app/c_src/erlxml.cc: In function 'ERL_NIF_TERM enif_stream_parser_new(ErlNifEnv*, int, const ERL_NIF_TERM*)':
/usr/lib/erlang/erts-10.2.4/include/erl_nif_api_funcs.h:625:79: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  625 | #  define enif_make_pid(ENV, PID) ((void)(ENV),(const ERL_NIF_TERM)((PID)->pid))
      |                                                                               ^
/app/c_src/erlxml.cc:130:29: note: in expansion of macro 'enif_make_pid'
  130 |     nif_stream->owner_pid = enif_make_pid(env, &current_pid);
      |                             ^~~~~~~~~~~~~
/app/c_src/erlxml.cc: In function 'ERL_NIF_TERM enif_stream_parser_feed(ErlNifEnv*, int, const ERL_NIF_TERM*)':
/usr/lib/erlang/erts-10.2.4/include/erl_nif_api_funcs.h:625:79: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  625 | #  define enif_make_pid(ENV, PID) ((void)(ENV),(const ERL_NIF_TERM)((PID)->pid))
      |                                                                               ^
/app/c_src/erlxml.cc:154:78: note: in expansion of macro 'enif_make_pid'
  154 |     if(enif_self(env, &current_pid) && !enif_is_identical(stream->owner_pid, enif_make_pid(env, &current_pid)))
      |                                                                              ^~~~~~~~~~~~~
/app/c_src/erlxml.cc: In function 'ERL_NIF_TERM enif_stream_parser_reset(ErlNifEnv*, int, const ERL_NIF_TERM*)':
/usr/lib/erlang/erts-10.2.4/include/erl_nif_api_funcs.h:625:79: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  625 | #  define enif_make_pid(ENV, PID) ((void)(ENV),(const ERL_NIF_TERM)((PID)->pid))
      |                                                                               ^
/app/c_src/erlxml.cc:197:78: note: in expansion of macro 'enif_make_pid'
  197 |     if(enif_self(env, &current_pid) && !enif_is_identical(stream->owner_pid, enif_make_pid(env, &current_pid)))
      |                                                                              ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[1]: *** [nif.mk:78: /app/c_src/erlxml.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/app/c_src'
make: *** [Makefile:2: compile] Error 2
```